### PR TITLE
feat: add rule validation

### DIFF
--- a/api/routers/rules.py
+++ b/api/routers/rules.py
@@ -62,13 +62,35 @@ def get_rule(rule_id: str, db: Session = Depends(get_db)) -> Rule:
     return rule
 
 
+def _validate_threshold_for_dimension(threshold: float, dimension: str) -> None:
+    """Validate threshold range based on dimension type."""
+    if dimension in {'completeness', 'uniqueness', 'validity'}:
+        if not (0 <= threshold <= 100):
+            raise HTTPException(
+                status_code=422,
+                detail=[{
+                    "type": "value_error",
+                    "loc": ["body", "threshold"],
+                    "msg": f"threshold for {dimension} dimension must be between 0 and 100",
+                    "input": threshold
+                }]
+            )
+
+
 @router.put("/{rule_id}", response_model=RuleResponse)
 def update_rule(rule_id: str, update: RuleUpdate, db: Session = Depends(get_db)) -> Rule:
     """Update an existing rule."""
     rule = db.query(Rule).filter(Rule.id == rule_id).first()
     if not rule:
         raise HTTPException(status_code=404, detail="Rule not found")
+
     update_data = update.model_dump(exclude_unset=True)
+
+    # Validate threshold against dimension (existing or updated)
+    if "threshold" in update_data and update_data["threshold"] is not None:
+        dimension = update_data.get("dimension", rule.dimension)
+        _validate_threshold_for_dimension(update_data["threshold"], dimension)
+
     if "config" in update_data and update_data["config"] is not None:
         update_data["config"] = json.dumps(update_data["config"])
     for field, value in update_data.items():

--- a/api/schemas/rules.py
+++ b/api/schemas/rules.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator, model_validator, ValidationInfo
 
 
 class RuleCreate(BaseModel):
@@ -19,6 +19,32 @@ class RuleCreate(BaseModel):
     config: Optional[dict] = None
     severity: str = Field(default="warning", pattern="^(info|warning|critical)$")
 
+    @field_validator('operator')
+    @classmethod
+    def validate_operator(cls, v: Optional[str]) -> Optional[str]:
+        """Validate operator is one of allowed values."""
+        if v is None:
+            return v
+        valid_operators = {'gte', 'lte', 'gt', 'lt', 'eq'}
+        if v not in valid_operators:
+            raise ValueError(f'operator must be one of: {", ".join(sorted(valid_operators))}')
+        return v
+
+    @field_validator('threshold')
+    @classmethod
+    def validate_threshold(cls, v: Optional[float], info: ValidationInfo) -> Optional[float]:
+        """Validate threshold range based on dimension type."""
+        if v is None:
+            return v
+
+        # Get dimension from values dict (it's validated before threshold)
+        dimension = info.data.get('dimension') if info.data else None
+        if dimension in {'completeness', 'uniqueness', 'validity'}:
+            if not (0 <= v <= 100):
+                raise ValueError(f'threshold for {dimension} dimension must be between 0 and 100')
+
+        return v
+
 
 class RuleUpdate(BaseModel):
     """Schema for updating a rule."""
@@ -32,6 +58,32 @@ class RuleUpdate(BaseModel):
     config: Optional[dict] = None
     severity: Optional[str] = Field(None, pattern="^(info|warning|critical)$")
     is_active: Optional[bool] = None
+
+    @field_validator('operator')
+    @classmethod
+    def validate_operator(cls, v: Optional[str]) -> Optional[str]:
+        """Validate operator is one of allowed values."""
+        if v is None:
+            return v
+        valid_operators = {'gte', 'lte', 'gt', 'lt', 'eq'}
+        if v not in valid_operators:
+            raise ValueError(f'operator must be one of: {", ".join(sorted(valid_operators))}')
+        return v
+
+    @field_validator('threshold')
+    @classmethod
+    def validate_threshold(cls, v: Optional[float], info: ValidationInfo) -> Optional[float]:
+        """Validate threshold range based on dimension type."""
+        if v is None:
+            return v
+
+        # Get dimension from values dict (it's validated before threshold)
+        dimension = info.data.get('dimension') if info.data else None
+        if dimension in {'completeness', 'uniqueness', 'validity'}:
+            if not (0 <= v <= 100):
+                raise ValueError(f'threshold for {dimension} dimension must be between 0 and 100')
+
+        return v
 
 
 class RuleResponse(BaseModel):

--- a/tests/test_api_rules.py
+++ b/tests/test_api_rules.py
@@ -81,3 +81,133 @@ def test_filter_by_dimension():
     client.post("/api/rules", json={"name": "r2", "dimension": "uniqueness"})
     resp = client.get("/api/rules?dimension=completeness")
     assert resp.json()["total"] == 1
+
+
+# Validation tests
+def test_create_rule_invalid_dimension():
+    """Test creating a rule with invalid dimension returns 422."""
+    resp = client.post("/api/rules", json={
+        "name": "test_rule",
+        "dimension": "banana",
+    })
+    assert resp.status_code == 422
+    error_detail = resp.json()["detail"][0]
+    assert "dimension" in error_detail["loc"]
+
+
+def test_create_rule_invalid_operator():
+    """Test creating a rule with invalid operator returns 422."""
+    resp = client.post("/api/rules", json={
+        "name": "test_rule",
+        "dimension": "completeness",
+        "operator": "yolo",
+    })
+    assert resp.status_code == 422
+    error_detail = resp.json()["detail"][0]
+    assert "operator must be one of:" in error_detail["msg"]
+
+
+def test_create_completeness_rule_invalid_threshold():
+    """Test creating a completeness rule with threshold > 100 returns 422."""
+    resp = client.post("/api/rules", json={
+        "name": "test_rule",
+        "dimension": "completeness",
+        "threshold": 150.0,
+    })
+    assert resp.status_code == 422
+    error_detail = resp.json()["detail"][0]
+    assert "must be between 0 and 100" in error_detail["msg"]
+
+
+def test_create_uniqueness_rule_invalid_threshold():
+    """Test creating a uniqueness rule with threshold > 100 returns 422."""
+    resp = client.post("/api/rules", json={
+        "name": "test_rule",
+        "dimension": "uniqueness",
+        "threshold": 150.0,
+    })
+    assert resp.status_code == 422
+    error_detail = resp.json()["detail"][0]
+    assert "must be between 0 and 100" in error_detail["msg"]
+
+
+def test_create_validity_rule_invalid_threshold():
+    """Test creating a validity rule with threshold > 100 returns 422."""
+    resp = client.post("/api/rules", json={
+        "name": "test_rule",
+        "dimension": "validity",
+        "threshold": 150.0,
+    })
+    assert resp.status_code == 422
+    error_detail = resp.json()["detail"][0]
+    assert "must be between 0 and 100" in error_detail["msg"]
+
+
+def test_create_accuracy_rule_high_threshold_allowed():
+    """Test creating an accuracy rule with threshold > 100 is allowed (not percentage-based)."""
+    resp = client.post("/api/rules", json={
+        "name": "test_rule",
+        "dimension": "accuracy",
+        "threshold": 150.0,
+    })
+    assert resp.status_code == 201
+    assert resp.json()["threshold"] == 150.0
+
+
+def test_create_consistency_rule_high_threshold_allowed():
+    """Test creating a consistency rule with threshold > 100 is allowed."""
+    resp = client.post("/api/rules", json={
+        "name": "test_rule",
+        "dimension": "consistency",
+        "threshold": 200.0,
+    })
+    assert resp.status_code == 201
+    assert resp.json()["threshold"] == 200.0
+
+
+def test_create_timeliness_rule_high_threshold_allowed():
+    """Test creating a timeliness rule with threshold > 100 is allowed."""
+    resp = client.post("/api/rules", json={
+        "name": "test_rule",
+        "dimension": "timeliness",
+        "threshold": 500.0,
+    })
+    assert resp.status_code == 201
+    assert resp.json()["threshold"] == 500.0
+
+
+def test_update_rule_invalid_operator():
+    """Test updating a rule with invalid operator returns 422."""
+    create_resp = client.post("/api/rules", json={"name": "r1", "dimension": "completeness"})
+    rule_id = create_resp.json()["id"]
+
+    resp = client.put(f"/api/rules/{rule_id}", json={"operator": "invalid"})
+    assert resp.status_code == 422
+    error_detail = resp.json()["detail"][0]
+    assert "operator must be one of:" in error_detail["msg"]
+
+
+def test_update_rule_invalid_threshold():
+    """Test updating a percentage-based rule with invalid threshold returns 422."""
+    create_resp = client.post("/api/rules", json={"name": "r1", "dimension": "completeness"})
+    rule_id = create_resp.json()["id"]
+
+    resp = client.put(f"/api/rules/{rule_id}", json={"threshold": 150.0})
+    assert resp.status_code == 422
+    error_detail = resp.json()["detail"][0]
+    assert "must be between 0 and 100" in error_detail["msg"]
+
+
+def test_create_rule_valid_operators():
+    """Test all valid operators are accepted."""
+    valid_operators = ["gte", "lte", "gt", "lt", "eq"]
+
+    for i, operator in enumerate(valid_operators):
+        resp = client.post("/api/rules", json={
+            "name": f"test_rule_{i}",
+            "dimension": "completeness",
+            "operator": operator,
+            "threshold": 90.0,
+        })
+        assert resp.status_code == 201
+        assert resp.json()["operator"] == operator


### PR DESCRIPTION
## Summary
• Add validation to rules API to reject invalid dimensions, operators, and thresholds with clear 422 errors
• Implement Pydantic field validators for operator validation (gte, lte, gt, lt, eq)
• Add threshold range validation for percentage-based dimensions (completeness, uniqueness, validity: 0-100)
• Allow unlimited thresholds for non-percentage dimensions (accuracy, consistency, timeliness)

## Test plan
- [x] Invalid dimension "banana" → 422 error
- [x] Invalid operator "yolo" → 422 error  
- [x] Completeness rule with threshold 150 → 422 error
- [x] Accuracy rule with threshold 150 → 201 (allowed)
- [x] All existing tests still pass
- [x] Update endpoint properly validates against existing dimension

🤖 Generated with [Claude Code](https://claude.com/claude-code)